### PR TITLE
feat: Updated macro view api_gateway_method_settings

### DIFF
--- a/transformations/aws/macros/apigateway/api_gateway_method_settings.sql
+++ b/transformations/aws/macros/apigateway/api_gateway_method_settings.sql
@@ -5,27 +5,44 @@
 {% macro default__api_gateway_method_settings() %}{% endmacro %}
 
 {% macro postgres__api_gateway_method_settings() %}
+with apigateway_rest_api_stages as(
+  select
+    *,
+    method_settings::text = '{}'::text as is_empty_method_settings
+  from aws_apigateway_rest_api_stages
+)
 select
-    s.arn,
-    s.rest_api_arn,
-    s.stage_name,
-    s.tracing_enabled as stage_data_trace_enabled,
-    s.cache_cluster_enabled as stage_caching_enabled,
-    s.web_acl_arn as waf,
-    s.client_certificate_id as cert,
-    key as method,
-    (
-        value::JSON -> 'DataTraceEnabled'
-    )::TEXT::BOOLEAN as data_trace_enabled,
-    (value::JSON -> 'CachingEnabled')::TEXT::BOOLEAN as caching_enabled,
-    (
-        value::JSON -> 'CacheDataEncrypted'
-    )::TEXT::BOOLEAN as cache_data_encrypted,
-    (value::JSON -> 'LoggingLevel')::TEXT as logging_level,
-    r.account_id
-from aws_apigateway_rest_api_stages s, aws_apigateway_rest_apis r,
-    JSONB_EACH_TEXT(s.method_settings)
-where s.rest_api_arn=r.arn
+     s.arn,
+     s.rest_api_arn,
+	 s.stage_name,
+	 s.tracing_enabled as stage_data_trace_enabled,
+     s.cache_cluster_enabled as stage_caching_enabled,
+     s.web_acl_arn as waf,
+     s.client_certificate_id as cert,
+case when (s.is_empty_method_settings = false)
+        then (select key from JSONB_EACH_TEXT(s.method_settings))
+        else '/*/'
+    end as method,
+    case when (s.is_empty_method_settings = false)
+        then (select (value::JSON -> 'DataTraceEnabled')::TEXT::BOOLEAN from JSONB_EACH_TEXT(s.method_settings))
+        else false
+    end as data_trace_enabled,
+    case when (s.is_empty_method_settings = false)
+        then (select (value::JSON -> 'CachingEnabled')::TEXT::BOOLEAN from JSONB_EACH_TEXT(s.method_settings))
+        else false
+    end as caching_enabled,
+    case when (s.is_empty_method_settings = false)
+        then (select (value::JSON -> 'CacheDataEncrypted')::TEXT::BOOLEAN from JSONB_EACH_TEXT(s.method_settings))
+        else false
+    end as cache_data_encrypted,
+    case when (s.is_empty_method_settings = false)
+        then (select (value::JSON -> 'LoggingLevel')::TEXT from JSONB_EACH_TEXT(s.method_settings))
+        else '"OFF"'
+   end as logging_level,
+     r.account_id
+
+from apigateway_rest_api_stages s, aws_apigateway_rest_apis r
+ where s.rest_api_arn=r.arn
 
 {% endmacro %}
 


### PR DESCRIPTION
When a new instance is created in the API Gateway, the default value for the method_settings becomes an empty JSON object ({}). When the JSONB_EACH_TEXT function is used, it doesn't expand the JSON data at all, and it remains empty.
As it's a JSON object, attempts to expand it using jsonb_array_elements do not work.
best approach is to handle this case specifically with checking the method_settings column and creating default values if needed.