### PR TITLE
chore: Delete `aws` directory

### DIFF
--- a/aws/foundational_security/snowflake/CHANGELOG.md
+++ b/aws/foundational_security/snowflake/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-
-## [1.8.0](https://github.com/cloudquery/policies-premium/compare/aws-foundational_security-snowflake-v1.7.0...aws-foundational_security-snowflake-v1.8.0) (2023-11-07)
-
-
-### Features
-
-* Move aws/snowflake to dbt ([#157](https://github.com/cloudquery/policies-premium/issues/157)) ([cad428c](https://github.com/cloudquery/policies-premium/commit/cad428c58481ff2596b795e4bef26ddbb88a5dd4))
-* Reorder things and move to cross platform queries ([#160](https://github.com/cloudquery/policies-premium/issues/160)) ([2e9e699](https://github.com/cloudquery/policies-premium/commit/2e9e6995991e12f4e6df7b73e6f7d662b0f56430))


### PR DESCRIPTION
This file seems like a left over from moving the policies around