### PR TITLE
chore: Organize `.gitignore`

### DIFF
--- a/transformations/.gitignore
+++ b/transformations/.gitignore
@@ -2,3 +2,5 @@
 target/
 dbt_packages/
 logs/
+build
+.cq

--- a/transformations/aws_compliance/.gitignore
+++ b/transformations/aws_compliance/.gitignore
@@ -1,2 +1,0 @@
-build
-.cq

--- a/transformations/aws_compliance/dbt_packages/utils
+++ b/transformations/aws_compliance/dbt_packages/utils
@@ -1,1 +1,0 @@
-/Users/yevgenyp/policies-premium/transformations/utils

--- a/transformations/aws_cost/.gitignore
+++ b/transformations/aws_cost/.gitignore
@@ -1,4 +1,0 @@
-
-target/
-dbt_packages/
-logs/

--- a/transformations/aws_encryption/.gitignore
+++ b/transformations/aws_encryption/.gitignore
@@ -1,4 +1,0 @@
-
-target/
-dbt_packages/
-logs/

--- a/transformations/azure_compliance/.gitignore
+++ b/transformations/azure_compliance/.gitignore
@@ -1,4 +1,0 @@
-
-target/
-dbt_packages/
-logs/

--- a/transformations/dbt_packages/utils
+++ b/transformations/dbt_packages/utils
@@ -1,1 +1,0 @@
-/Users/yevgenyp/policies-premium/transformations/utils

--- a/transformations/k8s_compliance/dbt_packages/utils
+++ b/transformations/k8s_compliance/dbt_packages/utils
@@ -1,1 +1,0 @@
-/Users/benbernays/Documents/GitHub/policies-premium/transformations/utils


### PR DESCRIPTION
Uses the same `.gitignore` for all transformations. Removes leftover `dbt_packages`