### PR TITLE
chore(ci): Configure release please for transformation `aws_compliance`

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,10 +1,12 @@
 {
   "packages": {
-    "aws/foundational_security/snowflake": {
-      "component": "aws-foundational_security-snowflake"
+    "transformations/aws_compliance": {
+      "component": "transformation-aws-compliance-free",
+      "changelog-path": "CHANGELOG.md"
     },
-    "aws/cost/postgresql": {
-      "component": "aws-cost-postgresql"
+    "transformation-aws-compliance": {
+      "component": "transformation-aws-compliance-paid",
+      "changelog-path": "CHANGELOG-PREMIUM.md"
     }
   },
   "pull-request-title-pattern": "chore${scope}: Release${component} v${version}",

--- a/transformations/aws_compliance/changelog.md
+++ b/transformations/aws_compliance/changelog.md
@@ -1,1 +1,0 @@
-new version


### PR DESCRIPTION
Part of https://github.com/cloudquery/cloudquery-issues/issues/896.

This should allow us to create release PRs for a free and paid version with different tags. We can trigger different publishing workflows based on the tags