### PR TITLE
chore: Add publishing for all free compliance transformations

### DIFF
--- a/.release-please-manifest-free.json
+++ b/.release-please-manifest-free.json
@@ -1,1 +1,6 @@
-{"transformations/aws_compliance":"0.0.1"}
+{
+  "transformations/aws_compliance": "0.0.1",
+  "transformations/azure_compliance": "0.0.1",
+  "transformations/gcp_compliance": "0.0.1",
+  "transformations/k8s_compliance": "0.0.1"
+}

--- a/release-please-config-free.json
+++ b/release-please-config-free.json
@@ -3,6 +3,18 @@
     "transformations/aws_compliance": {
       "component": "transformation-aws-compliance-free",
       "changelog-path": "CHANGELOG-free.md"
+    },
+    "transformations/azure_compliance": {
+      "component": "transformation-azure-compliance-free",
+      "changelog-path": "CHANGELOG-free.md"
+    },
+    "transformations/gcp_compliance": {
+      "component": "transformation-gcp-compliance-free",
+      "changelog-path": "CHANGELOG-free.md"
+    },
+    "transformations/k8s_compliance": {
+      "component": "transformation-k8s-compliance-free",
+      "changelog-path": "CHANGELOG-free.md"
     }
   },
   "pull-request-title-pattern": "chore${scope}: Release${component} v${version}",

--- a/transformations/aws_compliance/README-free.md
+++ b/transformations/aws_compliance/README-free.md
@@ -8,17 +8,18 @@
 - [CloudQuery](https://www.cloudquery.io/docs/quickstart)
 
 One of the below databases
+
 - [PostgreSQL](https://hub.cloudquery.io/plugins/destination/cloudquery/postgresql/v6.1.3/docs)
 - [Snowflake](https://hub.cloudquery.io/plugins/destination/cloudquery/snowflake/v3.3.3/docs)
 
 ### What's in the pack
 
-The pack contains a free version and a full (paid) version.
+The pack contains the free version.
 
 #### Models
 
-- **aws_compliance__cis_v1.2.0**: AWS CIS V1.2.0 benchmarks, available for PostgreSQL
+- **aws_compliance\_\_cis_v1.2.0**: AWS CIS V1.2.0 benchmarks, available for PostgreSQL
 - **aws_compliance_pci_dss_v3.2.1**: AWS PCI DSS V3.2.1 benchmark.
-- **aws_compliance__foundational_security**: AWS Foundational Security benchmark, available only for Snoflake
+- **aws_compliance\_\_foundational_security**: AWS Foundational Security benchmark, available only for Snowflake
 
 The free version contains 10% of the full pack's queries.

--- a/transformations/aws_compliance/manifest-free.json
+++ b/transformations/aws_compliance/manifest-free.json
@@ -6,7 +6,7 @@
   "addon_type": "transformation",
   "addon_format": "zip",
   "message": "./changelog.md",
-  "doc": "./README.md",
+  "doc": "./README-free.md",
   "path": "./build/aws_compliance_free.zip",
   "plugin_deps": ["cloudquery/source/aws@v22.18.0"],
   "addon_deps": []

--- a/transformations/azure_compliance/CHANGELOG.md
+++ b/transformations/azure_compliance/CHANGELOG.md
@@ -1,1 +1,0 @@
-Azure Compliance Pack V1.0.0

--- a/transformations/azure_compliance/Makefile
+++ b/transformations/azure_compliance/Makefile
@@ -10,8 +10,3 @@ build-free:
 	cp -r models/free ./build/azure_compliance_free/models/.
 	cp dbt_project.yml ./build/azure_compliance_free/
 	zip -r ./build/azure_compliance_free.zip ./build/azure_compliance_free
-
-.PHONY: publish-free
-publish-free: build-free
-	@echo "Publishing free tier compliance pack"
-	cloudquery addon publish ./manifest-free.json v1.0.1 --finalize

--- a/transformations/azure_compliance/README-free.md
+++ b/transformations/azure_compliance/README-free.md
@@ -15,7 +15,7 @@ This package contains dbt models (views) that gives compliance insights from Clo
 - [DBT + Snowflake](https://docs.getdbt.com/docs/core/connect-data-platform/snowflake-setup)
 - [DBT + Postgres](https://docs.getdbt.com/docs/core/connect-data-platform/postgres-setup)
 - [DBT + BigQuery](https://docs.getdbt.com/docs/core/connect-data-platform/bigquery-setup)
-  
+
 An example of how to install dbt to work with the destination of your choice.
 
 First, install `dbt` for the destination of your choice:
@@ -27,12 +27,12 @@ pip install dbt-postgres
 ```
 
 An example installation of dbt-snowflake:
+
 ```bash
 pip install dbt-snowflake
 ```
 
 These commands will also install install dbt-core and any other dependencies.
-
 
 Create the profile directory:
 
@@ -78,16 +78,17 @@ dbt compile
 ```
 
 One of the below databases
+
 - [PostgreSQL](https://hub.cloudquery.io/plugins/destination/cloudquery/postgresql/v6.1.3/docs)
 - [Snowflake](https://hub.cloudquery.io/plugins/destination/cloudquery/snowflake/v3.3.3/docs)
 
 ### What's in the pack
 
-The pack contains a free version and a full (paid) version.
+The pack contains the free version.
 
 #### Models
 
-- **azure_compliance__cis_v1_3_0.sql**: Azure Compliance CIS V1.3.0, available for PostgreSQL.
+- **azure_compliance\_\_cis_v1_3_0.sql**: Azure Compliance CIS V1.3.0, available for PostgreSQL.
 - **azure_compliance_hipaa_hitrust_v9_2.sql**: Azure Compliance HIPPA HITRUST V9.2, available for PostgreSQL.
 
 The free version contains 10% of the full pack's queries.

--- a/transformations/azure_compliance/manifest-free.json
+++ b/transformations/azure_compliance/manifest-free.json
@@ -5,8 +5,8 @@
   "addon_name": "azure-compliance-free",
   "addon_type": "transformation",
   "addon_format": "zip",
-  "message": "./CHANGELOG.md",
-  "doc": "./README.md",
+  "message": "./changelog.md",
+  "doc": "./README-free.md",
   "path": "./build/azure_compliance_free.zip",
   "plugin_deps": ["cloudquery/source/azure@v10.1.1"],
   "addon_deps": []

--- a/transformations/gcp_compliance/CHANGELOG.md
+++ b/transformations/gcp_compliance/CHANGELOG.md
@@ -1,1 +1,0 @@
-CIS V1.2.0 Version

--- a/transformations/gcp_compliance/Makefile
+++ b/transformations/gcp_compliance/Makefile
@@ -10,8 +10,3 @@ build-free:
 	cp -r models/free ./build/gcp_compliance_free/models/.
 	cp dbt_project.yml ./build/gcp_compliance_free/
 	zip -r ./build/gcp_compliance_free.zip ./build/gcp_compliance_free
-
-.PHONY: publish-free
-publish-free: build-free
-	@echo "Publishing free tier compliance pack"
-	cloudquery addon publish ./manifest-free.json v1.0.0 --finalize

--- a/transformations/gcp_compliance/README-free.md
+++ b/transformations/gcp_compliance/README-free.md
@@ -8,6 +8,7 @@
 - [CloudQuery](https://www.cloudquery.io/docs/quickstart)
 
 One of the below databases
+
 - [PostgreSQL](https://hub.cloudquery.io/plugins/destination/cloudquery/postgresql/v6.1.3/docs)
 - [Snowflake](https://hub.cloudquery.io/plugins/destination/cloudquery/snowflake/v3.3.3/docs)
 
@@ -21,12 +22,12 @@ An example of how to install dbt to work with the destination of your choice.
 
 First, install `dbt` for the destination of your choice:
 
-The pack contains a free version and a full (paid) version. 
+The pack contains the free version.
 The free version contains 10% of the full pack's queries.
 
 #### Models
 
-- **gcp_compliance__cis_v1.2.0**: GCP CIS V1.2.0 benchmarks, available for PostgreSQL
+- **gcp_compliance\_\_cis_v1.2.0**: GCP CIS V1.2.0 benchmarks, available for PostgreSQL
 
 #### Running Your dbt Project
 

--- a/transformations/gcp_compliance/manifest-free.json
+++ b/transformations/gcp_compliance/manifest-free.json
@@ -5,8 +5,8 @@
   "addon_name": "gcp-compliance-free",
   "addon_type": "transformation",
   "addon_format": "zip",
-  "message": "./CHANGELOG.md",
-  "doc": "./README.md",
+  "message": "./changelog.md",
+  "doc": "./README-free.md",
   "path": "./build/gcp_compliance_free.zip",
   "plugin_deps": ["cloudquery/source/gcp@v9.9.1"],
   "addon_deps": []

--- a/transformations/k8s_compliance/Makefile
+++ b/transformations/k8s_compliance/Makefile
@@ -10,8 +10,3 @@ build-free:
 	cp -r models/free ./build/k8s_compliance_free/models/.
 	cp dbt_project.yml ./build/k8s_compliance_free/
 	zip -r ./build/k8s_compliance_free.zip ./build/k8s_compliance_free
-
-.PHONY: publish-free
-publish-free: build-free
-	@echo "Publishing free tier compliance pack"
-	cloudquery addon publish ./manifest-free.json v1.0.0 --finalize

--- a/transformations/k8s_compliance/README-free.md
+++ b/transformations/k8s_compliance/README-free.md
@@ -11,16 +11,17 @@ This package contains dbt models (views) that gives compliance insights from Clo
 - [dbt](https://docs.getdbt.com/docs/installation)
 
 One of the below databases
+
 - [PostgreSQL](https://hub.cloudquery.io/plugins/destination/cloudquery/postgresql/v6.1.3/docs)
 - [Snowflake](https://hub.cloudquery.io/plugins/destination/cloudquery/snowflake/v3.3.3/docs)
 
 ### What's in the pack
 
-The pack contains a free version and a full (paid) version.
+The pack contains the free version.
 
 #### Models
 
-- **k8s_compliance__cis_v1_7.sql**: Kubernetes CIS V1.7 benchmarks, available for PostgreSQL.
-- **k8s_compliance__nsa_cisa_v1.sql**: Kubernetes NSA/CISA V1 benchmarks, available for PostgreSQL.
+- **k8s_compliance\_\_cis_v1_7.sql**: Kubernetes CIS V1.7 benchmarks, available for PostgreSQL.
+- **k8s_compliance\_\_nsa_cisa_v1.sql**: Kubernetes NSA/CISA V1 benchmarks, available for PostgreSQL.
 
 The free version contains 10% of the full pack's queries.

--- a/transformations/k8s_compliance/manifest-free.json
+++ b/transformations/k8s_compliance/manifest-free.json
@@ -5,8 +5,8 @@
   "addon_name": "k8s-compliance-free",
   "addon_type": "transformation",
   "addon_format": "zip",
-  "message": "./CHANGELOG.md",
-  "doc": "./README.md",
+  "message": "./changelog.md",
+  "doc": "./README-free.md",
   "path": "./build/k8s_compliance_free.zip",
   "plugin_deps": ["cloudquery/source/k8s@v5.2.1"],
   "addon_deps": []


### PR DESCRIPTION
I removed the manual publishing make file targets, and made the manifest files consistent