### PR TITLE
chore: Run migrate before pack

### DIFF
--- a/.github/workflows/publish_transformation.yml
+++ b/.github/workflows/publish_transformation.yml
@@ -71,6 +71,15 @@ jobs:
       - name: Install dependencies
         working-directory: transformations/${{ needs.prepare.outputs.transformation_dir }}
         run: pip install -r requirements.txt
+      - name: Setup CloudQuery
+        uses: cloudquery/setup-cloudquery@v3
+        with:
+          version: v4.0.0
+      - name: Migrate DB
+        run: cloudquery migrate tests/postgres.yml
+        working-directory: transformations/${{ needs.prepare.outputs.transformation_dir }}
+        env:
+          CQ_DSN: postgresql://postgres:pass@localhost:5432/postgres
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Looks like if tables are missing dbt don't include all dependencies