### PR TITLE
chore: Revert "chore(main): Release transformation-aws-asset-inventory-free v1.0.0 (#336)"

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -22,7 +22,5 @@
   "visualizations/aws/data_resilience": "1.1.0",
   "visualizations/aws/data_resilience+FILLER": "0.0.0",
   "transformations/aws/encryption": "1.0.1",
-  "transformations/aws/encryption+FILLER": "0.0.0",
-  "transformations/aws/asset-inventory-free": "1.0.0",
-  "transformations/aws/asset-inventory-free+FILLER": "0.0.0"
+  "transformations/aws/encryption+FILLER": "0.0.0"
 }

--- a/transformations/aws/asset-inventory-free/CHANGELOG.md
+++ b/transformations/aws/asset-inventory-free/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-## 1.0.0 (2023-12-05)
-
-
-### Features
-
-* AWS Asset Inventory Transformation ([#327](https://github.com/cloudquery/policies-premium/issues/327)) ([6ef8e43](https://github.com/cloudquery/policies-premium/commit/6ef8e43f618843f3431e112c8f4c62ac08296697))


### PR DESCRIPTION
This reverts commit be9183c8015d88fa4aa4449cf1a39b908c0f9503.

Going to re-release this one as the release was missing a file