### PR TITLE
chore: Remove `command` input from release PR workflow

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -16,6 +16,5 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:
-          command: manifest
           token: ${{ secrets.GH_CQ_BOT }}
           default-branch: main


### PR DESCRIPTION
Follow up to https://github.com/cloudquery/policies-premium/pull/345

The input was removed and v4 and no longer needed. The action and release please auto detects the manifest file