### PR TITLE
chore: Revert "chore(main): Release visualization-aws-asset-inventory v1.0.0"

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -23,6 +23,5 @@
   "visualizations/aws/data_resilience+FILLER": "0.0.0",
   "transformations/aws/encryption": "1.0.1",
   "transformations/aws/encryption+FILLER": "0.0.0",
-  "transformations/aws/asset-inventory-free": "1.0.0",
-  "visualizations/aws/asset_inventory": "1.0.0"
+  "transformations/aws/asset-inventory-free": "1.0.0"
 }

--- a/visualizations/aws/asset_inventory/CHANGELOG.md
+++ b/visualizations/aws/asset_inventory/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-## 1.0.0 (2023-12-06)
-
-
-### Features
-
-* Add asset inventory visualization ([#338](https://github.com/cloudquery/policies-premium/issues/338)) ([83c760c](https://github.com/cloudquery/policies-premium/commit/83c760c3402bc8ad11ba6d7e4260d24e37711625))


### PR DESCRIPTION
Reverts cloudquery/policies-premium#353

Reverts the previous release since the publishing workflow was broken