### PR TITLE
chore: Run dbt seed before dbt run

### DIFF
--- a/.github/workflows/validate_transformation_release.yml
+++ b/.github/workflows/validate_transformation_release.yml
@@ -131,14 +131,17 @@ jobs:
         if: needs.prepare.outputs.postgres == 'true'
         working-directory: ./temp/build
         run: |
+          dbt seed --target dev-pg --profiles-dir ./tests
           dbt run --target dev-pg --profiles-dir ../../${{ needs.prepare.outputs.transformation_dir }}/tests
       - name: Run Unpacked DBT Snowflake
         if: needs.prepare.outputs.snowflake == 'true'
         working-directory: ./temp/build
         run: |
+          dbt seed --target dev-snowflake --profiles-dir ./tests
           dbt run --target dev-snowflake --profiles-dir ../../${{ needs.prepare.outputs.transformation_dir }}/tests
       - name: Run Unpacked DBT BigQuery
         if: needs.prepare.outputs.bigquery == 'true'
         working-directory: ./temp/build
         run: |
+          dbt seed --target dev-bigquery --profiles-dir ./tests
           dbt run --target dev-bigquery --profiles-dir ../../${{ needs.prepare.outputs.transformation_dir }}/tests


### PR DESCRIPTION
Some packs (like) require a seed. If there's no seed it's a no-op 