### PR TITLE
chore: Remove `registry: cloudquery` from configs

### DIFF
--- a/transformations/aws/asset-inventory-free/tests/postgres.yml
+++ b/transformations/aws/asset-inventory-free/tests/postgres.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: "postgresql"
   path: "cloudquery/postgresql"
-  registry: cloudquery
   version: "v7.1.2" # latest version of postgresql plugin
   spec:
     batch_size: 10000

--- a/transformations/aws/compliance-free/tests/bigquery.yml
+++ b/transformations/aws/compliance-free/tests/bigquery.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: bigquery
   path: cloudquery/bigquery
-  registry: cloudquery
   version: "v3.3.9"
   write_mode: "append"
   spec:

--- a/transformations/aws/compliance-free/tests/postgres.yml
+++ b/transformations/aws/compliance-free/tests/postgres.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: "postgresql"
   path: "cloudquery/postgresql"
-  registry: cloudquery
   version: "v7.1.2" # latest version of postgresql plugin
   spec:
     batch_size: 10000

--- a/transformations/aws/compliance-free/tests/snowflake.yml
+++ b/transformations/aws/compliance-free/tests/snowflake.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: snowflake
   path: cloudquery/snowflake
-  registry: github
   version: "v3.3.5" # latest version of destination snowflake plugin
   spec:
     connection_string: ${SNOWFLAKE_CONNECTION_STRING}

--- a/transformations/aws/compliance-premium/tests/bigquery.yml
+++ b/transformations/aws/compliance-premium/tests/bigquery.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: bigquery
   path: cloudquery/bigquery
-  registry: cloudquery
   version: "v3.3.9"
   write_mode: "append"
   spec:

--- a/transformations/aws/compliance-premium/tests/postgres.yml
+++ b/transformations/aws/compliance-premium/tests/postgres.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: "postgresql"
   path: "cloudquery/postgresql"
-  registry: cloudquery
   version: "v7.1.2" # latest version of postgresql plugin
   spec:
     batch_size: 10000

--- a/transformations/aws/compliance-premium/tests/snowflake.yml
+++ b/transformations/aws/compliance-premium/tests/snowflake.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: snowflake
   path: cloudquery/snowflake
-  registry: github
   version: "v3.3.5" # latest version of destination snowflake plugin
   spec:
     connection_string: ${SNOWFLAKE_CONNECTION_STRING}

--- a/transformations/aws/cost/tests/postgres.yml
+++ b/transformations/aws/cost/tests/postgres.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: "postgresql"
   path: "cloudquery/postgresql"
-  registry: cloudquery
   version: "v7.1.2" # latest version of postgresql plugin
   spec:
     batch_size: 10000

--- a/transformations/aws/data-resilience/tests/postgres.yml
+++ b/transformations/aws/data-resilience/tests/postgres.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: "postgresql"
   path: "cloudquery/postgresql"
-  registry: cloudquery
   version: "v7.1.2" # latest version of postgresql plugin
   spec:
     batch_size: 10000

--- a/transformations/aws/encryption/tests/postgres.yml
+++ b/transformations/aws/encryption/tests/postgres.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: "postgresql"
   path: "cloudquery/postgresql"
-  registry: cloudquery
   version: "v7.1.2" # latest version of postgresql plugin
   spec:
     batch_size: 10000

--- a/transformations/azure/compliance-free/tests/postgres.yml
+++ b/transformations/azure/compliance-free/tests/postgres.yml
@@ -2,7 +2,6 @@ kind: source
 spec:
   name: azure
   path: cloudquery/azure
-  registry: cloudquery
   version: "v10.3.0" # latest version of source azure plugin
   destinations: ["postgresql"]
   tables: ["*"]
@@ -11,7 +10,6 @@ kind: destination
 spec:
   name: "postgresql"
   path: "cloudquery/postgresql"
-  registry: cloudquery
   version: "v7.1.2" # latest version of postgresql plugin
   spec:
     batch_size: 10000

--- a/transformations/azure/compliance-free/tests/snowflake.yml
+++ b/transformations/azure/compliance-free/tests/snowflake.yml
@@ -2,7 +2,6 @@ kind: source
 spec:
   name: azure
   path: cloudquery/azure
-  registry: cloudquery
   version: "v10.3.0" # latest version of source azure plugin
   destinations: ["snowflake"]
   tables: ["*"]
@@ -11,7 +10,6 @@ kind: destination
 spec:
   name: snowflake
   path: cloudquery/snowflake
-  registry: github
   version: "v3.3.5" # latest version of destination snowflake plugin
   spec:
     connection_string: ${SNOWFLAKE_CONNECTION_STRING}

--- a/transformations/azure/compliance-premium/tests/postgres.yml
+++ b/transformations/azure/compliance-premium/tests/postgres.yml
@@ -2,7 +2,6 @@ kind: source
 spec:
   name: azure
   path: cloudquery/azure
-  registry: cloudquery
   version: "v10.3.0" # latest version of source azure plugin
   destinations: ["postgresql"]
   tables: ["*"]
@@ -11,7 +10,6 @@ kind: destination
 spec:
   name: "postgresql"
   path: "cloudquery/postgresql"
-  registry: cloudquery
   version: "v7.1.2" # latest version of postgresql plugin
   spec:
     batch_size: 10000

--- a/transformations/azure/compliance-premium/tests/snowflake.yml
+++ b/transformations/azure/compliance-premium/tests/snowflake.yml
@@ -2,7 +2,6 @@ kind: source
 spec:
   name: azure
   path: cloudquery/azure
-  registry: cloudquery
   version: "v10.3.0" # latest version of source azure plugin
   destinations: ["snowflake"]
   tables: ["*"]
@@ -11,7 +10,6 @@ kind: destination
 spec:
   name: snowflake
   path: cloudquery/snowflake
-  registry: github
   version: "v3.3.5" # latest version of destination snowflake plugin
   spec:
     connection_string: ${SNOWFLAKE_CONNECTION_STRING}

--- a/transformations/gcp/compliance-free/tests/bigquery.yml
+++ b/transformations/gcp/compliance-free/tests/bigquery.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: bigquery
   path: cloudquery/bigquery
-  registry: cloudquery
   version: "v3.3.9"
   write_mode: "append"
   spec:

--- a/transformations/gcp/compliance-free/tests/postgres.yml
+++ b/transformations/gcp/compliance-free/tests/postgres.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: "postgresql"
   path: "cloudquery/postgresql"
-  registry: cloudquery
   version: "v7.1.2" # latest version of postgresql plugin
   spec:
     batch_size: 10000

--- a/transformations/gcp/compliance-free/tests/snowflake.yml
+++ b/transformations/gcp/compliance-free/tests/snowflake.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: snowflake
   path: cloudquery/snowflake
-  registry: github
   version: "v3.3.5" # latest version of destination snowflake plugin
   spec:
     connection_string: ${SNOWFLAKE_CONNECTION_STRING}

--- a/transformations/gcp/compliance-premium/tests/bigquery.yml
+++ b/transformations/gcp/compliance-premium/tests/bigquery.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: bigquery
   path: cloudquery/bigquery
-  registry: cloudquery
   version: "v3.3.9"
   write_mode: "append"
   spec:

--- a/transformations/gcp/compliance-premium/tests/postgres.yml
+++ b/transformations/gcp/compliance-premium/tests/postgres.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: "postgresql"
   path: "cloudquery/postgresql"
-  registry: cloudquery
   version: "v7.1.2" # latest version of postgresql plugin
   spec:
     batch_size: 10000

--- a/transformations/gcp/compliance-premium/tests/snowflake.yml
+++ b/transformations/gcp/compliance-premium/tests/snowflake.yml
@@ -10,7 +10,6 @@ kind: destination
 spec:
   name: snowflake
   path: cloudquery/snowflake
-  registry: github
   version: "v3.3.5" # latest version of destination snowflake plugin
   spec:
     connection_string: ${SNOWFLAKE_CONNECTION_STRING}

--- a/transformations/k8s/compliance-free/tests/postgres.yml
+++ b/transformations/k8s/compliance-free/tests/postgres.yml
@@ -3,7 +3,6 @@ spec:
   # Source spec section
   name: k8s
   path: cloudquery/k8s
-  registry: cloudquery
   version: "v5.2.3" # latest version of source k8s plugin
   tables: ["*"]
   destinations: ["postgresql"]
@@ -14,7 +13,6 @@ kind: destination
 spec:
   name: "postgresql"
   path: "cloudquery/postgresql"
-  registry: cloudquery
   version: "v7.1.2" # latest version of postgresql plugin
   spec:
     batch_size: 10000

--- a/transformations/k8s/compliance-premium/tests/postgres.yml
+++ b/transformations/k8s/compliance-premium/tests/postgres.yml
@@ -3,7 +3,6 @@ spec:
   # Source spec section
   name: k8s
   path: cloudquery/k8s
-  registry: cloudquery
   version: "v5.2.3" # latest version of source k8s plugin
   tables: ["*"]
   destinations: ["postgresql"]
@@ -14,7 +13,6 @@ kind: destination
 spec:
   name: "postgresql"
   path: "cloudquery/postgresql"
-  registry: cloudquery
   version: "v7.1.2" # latest version of postgresql plugin
   spec:
     batch_size: 10000


### PR DESCRIPTION
`registry: cloudquery` is the default so we can use it.

Also removed some left over `registry: github`