### PR TITLE
chore: Move validate transformation condition to steps instead of job

### DIFF
--- a/.github/workflows/validate_transformation_release.yml
+++ b/.github/workflows/validate_transformation_release.yml
@@ -17,7 +17,6 @@ env:
 jobs:
   prepare:
     runs-on: ubuntu-latest
-    if: startsWith(github.head_ref, 'release-please--branches--main--components--transformation-')
     outputs:
       transformation_dir: ${{ fromJson(steps.set-result.outputs.result).transformation_dir }}
       zipPath: ${{ fromJson(steps.set-result.outputs.result).zipPath }}
@@ -26,6 +25,7 @@ jobs:
       bigquery: ${{ fromJson(steps.set-result.outputs.result).bigquery }}
     steps:
       - name: Checkout
+        if: startsWith(github.head_ref, 'release-please--branches--main--components--transformation-')
         uses: actions/checkout@v4
       - uses: actions/github-script@v7
         id: set-result
@@ -33,6 +33,9 @@ jobs:
           PR_BRANCH: ${{ github.head_ref }}
         with:
           script: |
+            if (!process.env.PR_BRANCH.startsWith('release-please--branches--main--components--transformation-')) {
+              return {}
+            }
             const path = require('path');
             const fs = require('fs/promises');
             const { PR_BRANCH } = process.env;
@@ -76,22 +79,27 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout
+        if: startsWith(github.head_ref, 'release-please--branches--main--components--transformation-')
         uses: actions/checkout@v4
       # Required for BigQuery targets
       - name: Authenticate to Google Cloud
+        if: startsWith(github.head_ref, 'release-please--branches--main--components--transformation-')
         uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: 'projects/151868820337/locations/global/workloadIdentityPools/integration-test-pool/providers/integration-test-provider'
           service_account: 'integration-service-account@cq-integration-tests.iam.gserviceaccount.com'
       - uses: actions/setup-python@v5
+        if: startsWith(github.head_ref, 'release-please--branches--main--components--transformation-')
         with:
           python-version: "3.9"
           cache: "pip"
           cache-dependency-path: "./${{ needs.prepare.outputs.transformation_dir }}/requirements.txt"
       - name: Install dependencies
+        if: startsWith(github.head_ref, 'release-please--branches--main--components--transformation-')
         working-directory: ${{ needs.prepare.outputs.transformation_dir }}
         run: pip install -r requirements.txt
       - name: Setup CloudQuery
+        if: startsWith(github.head_ref, 'release-please--branches--main--components--transformation-')
         uses: cloudquery/setup-cloudquery@v3
         with:
           version: v5.0.1
@@ -112,18 +120,22 @@ jobs:
         run: cloudquery migrate tests/bigquery.yml
         working-directory: ${{ needs.prepare.outputs.transformation_dir }}
       - name: Setup Node.js
+        if: startsWith(github.head_ref, 'release-please--branches--main--components--transformation-')
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
           cache: 'npm'
           cache-dependency-path: scripts/dbt-pack/package-lock.json
       - name: Install Dependencies
+        if: startsWith(github.head_ref, 'release-please--branches--main--components--transformation-')
         run: npm ci
         working-directory: ./scripts/dbt-pack
       - name: Pack DBT
+        if: startsWith(github.head_ref, 'release-please--branches--main--components--transformation-')
         working-directory: ./scripts/dbt-pack
         run: node index.js dbt-pack --project-dir=../../${{ needs.prepare.outputs.transformation_dir }}
       - name: Unzip Packed DBT
+        if: startsWith(github.head_ref, 'release-please--branches--main--components--transformation-')
         run: |
           mkdir -p temp/build
           unzip -o ${{ needs.prepare.outputs.zipPath }} -d temp/build


### PR DESCRIPTION
This should allow us to enforce the `validate-transformation` check as required in branch protection rules