### PR TITLE
feat: Added queries for Foundational Security compliance for BigQuery

### DIFF
--- a/transformations/aws/compliance-premium/README.md
+++ b/transformations/aws/compliance-premium/README.md
@@ -394,4 +394,3 @@ The premium version contains all checks.
 - ✅ `RDS`: `rds_db_instances_should_prohibit_public_access`
 - ✅ `Redshift`: `cluster_publicly_accessible`
 <!-- AUTO-GENERATED-INCLUDED-CHECKS-END -->
-


### PR DESCRIPTION
To trigger a release only for AWS instead of https://github.com/cloudquery/policies-premium/pull/515