### PR TITLE
fix: Update dependencies

### DIFF
--- a/transformations/aws/asset-inventory-free/requirements.txt
+++ b/transformations/aws/asset-inventory-free/requirements.txt
@@ -1,1 +1,1 @@
-dbt-postgres==1.7.9
+dbt-postgres==1.7.10

--- a/transformations/aws/compliance-free/requirements.txt
+++ b/transformations/aws/compliance-free/requirements.txt
@@ -1,3 +1,3 @@
-dbt-postgres==1.7.9
+dbt-postgres==1.7.10
 dbt-bigquery==1.7.6
 dbt-snowflake==1.7.2

--- a/transformations/aws/compliance-premium/requirements.txt
+++ b/transformations/aws/compliance-premium/requirements.txt
@@ -1,3 +1,3 @@
-dbt-postgres==1.7.9
+dbt-postgres==1.7.10
 dbt-bigquery==1.7.6
 dbt-snowflake==1.7.2

--- a/transformations/aws/cost-free/requirements.txt
+++ b/transformations/aws/cost-free/requirements.txt
@@ -1,1 +1,1 @@
-dbt-postgres==1.7.9
+dbt-postgres==1.7.10

--- a/transformations/aws/cost/requirements.txt
+++ b/transformations/aws/cost/requirements.txt
@@ -1,1 +1,1 @@
-dbt-postgres==1.7.9
+dbt-postgres==1.7.10

--- a/transformations/aws/data-resilience/requirements.txt
+++ b/transformations/aws/data-resilience/requirements.txt
@@ -1,1 +1,1 @@
-dbt-postgres==1.7.9
+dbt-postgres==1.7.10

--- a/transformations/aws/encryption/requirements.txt
+++ b/transformations/aws/encryption/requirements.txt
@@ -1,1 +1,1 @@
-dbt-postgres==1.7.9
+dbt-postgres==1.7.10

--- a/transformations/azure/compliance-free/requirements.txt
+++ b/transformations/azure/compliance-free/requirements.txt
@@ -1,3 +1,3 @@
-dbt-postgres==1.7.9
+dbt-postgres==1.7.10
 dbt-snowflake==1.7.2
 dbt-bigquery==1.7.6

--- a/transformations/azure/compliance-premium/requirements.txt
+++ b/transformations/azure/compliance-premium/requirements.txt
@@ -1,3 +1,3 @@
-dbt-postgres==1.7.9
+dbt-postgres==1.7.10
 dbt-snowflake==1.7.2
 dbt-bigquery==1.7.6

--- a/transformations/gcp/compliance-free/requirements.txt
+++ b/transformations/gcp/compliance-free/requirements.txt
@@ -1,3 +1,3 @@
-dbt-postgres==1.7.9
+dbt-postgres==1.7.10
 dbt-bigquery==1.7.6
 dbt-snowflake==1.7.2

--- a/transformations/gcp/compliance-premium/requirements.txt
+++ b/transformations/gcp/compliance-premium/requirements.txt
@@ -1,3 +1,3 @@
-dbt-postgres==1.7.9
+dbt-postgres==1.7.10
 dbt-bigquery==1.7.6
 dbt-snowflake==1.7.2

--- a/transformations/k8s/compliance-free/requirements.txt
+++ b/transformations/k8s/compliance-free/requirements.txt
@@ -1,1 +1,1 @@
-dbt-postgres==1.7.9
+dbt-postgres==1.7.10

--- a/transformations/k8s/compliance-premium/requirements.txt
+++ b/transformations/k8s/compliance-premium/requirements.txt
@@ -1,1 +1,1 @@
-dbt-postgres==1.7.9
+dbt-postgres==1.7.10


### PR DESCRIPTION
This pr updates the `dbt-postgres` package from `1.7.9` to `1.7.10` because internal to that package it was using any version of `protobuf>=4.0.0` and `v5` introduced some breaking changes.

In `1.7.10` they pinned protobuf to v4

https://github.com/dbt-labs/dbt-core/releases/tag/v1.7.10