### PR TITLE
feat: Fix iam.6 logic in AWS Foundational Security

### DIFF
--- a/transformations/aws/macros/iam/hardware_mfa_enabled_for_root.sql
+++ b/transformations/aws/macros/iam/hardware_mfa_enabled_for_root.sql
@@ -10,8 +10,8 @@ select
   split_part(cr.arn, ':', 5) as account_id,
   cr.arn as resource_id,
   case
-    when cr.mfa_active = FALSE and (mfa.serial_number like 'arn%' or mfa.serial_number is null) then 'fail'
-    when (mfa.serial_number not like 'arn%' or mfa.serial_number is not null) and cr.mfa_active = TRUE then 'pass'
+    when cr.mfa_active = FALSE or mfa.serial_number like 'arn%' or mfa.serial_number is null then 'fail'
+    when mfa.serial_number not like 'arn%' and mfa.serial_number is not null and cr.mfa_active = TRUE then 'pass'
   end as status
 from aws_iam_credential_reports cr
 left join
@@ -29,8 +29,8 @@ select
   split_part(cr.arn, ':', 5) as account_id,
   cr.arn as resource_id,
   case
-    when cr.mfa_active = FALSE and (mfa.serial_number like 'arn%' or mfa.serial_number is null) then 'fail'
-    when (mfa.serial_number not like 'arn%' or mfa.serial_number is not null) and cr.mfa_active = TRUE then 'pass'
+    when cr.mfa_active = FALSE or mfa.serial_number like 'arn%' or mfa.serial_number is null then 'fail'
+    when mfa.serial_number not like 'arn%' and mfa.serial_number is not null and cr.mfa_active = TRUE then 'pass'
   end as status
 from aws_iam_credential_reports cr
 left join
@@ -48,8 +48,8 @@ select
   SPLIT(cr.arn, ':')[SAFE_OFFSET(4)] AS account_id,
   cr.arn as resource_id,
   case
-    when cr.mfa_active = FALSE and (mfa.serial_number like 'arn%' or mfa.serial_number is null) then 'fail'
-    when (mfa.serial_number not like 'arn%' or mfa.serial_number is not null) and cr.mfa_active = TRUE then 'pass'
+    when cr.mfa_active = FALSE or mfa.serial_number like 'arn%' or mfa.serial_number is null then 'fail'
+    when mfa.serial_number not like 'arn%' and mfa.serial_number is not null and cr.mfa_active = TRUE then 'pass'
   end as status
 from {{ full_table_name("aws_iam_credential_reports") }} cr
 left join


### PR DESCRIPTION
Docs: https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-6

Relevant snippet:

> This control checks whether your AWS account is enabled to use a hardware multi-factor authentication (MFA) device to sign in with root user credentials. The control fails if MFA isn't enabled or if any virtual MFA devices are permitted for signing in with root user credentials.

> Virtual MFA might not provide the same level of security as hardware MFA devices. We recommend that you use only a virtual MFA device while you wait for hardware purchase approval or for your hardware to arrive.

Per the above docs, I took out the `when mfa.serial_number is null` logic from the fail criteria and added that to the pass criteria. The ideal pass scenario per the docs should be when the virtual mfa device serial_number *is* null *and* mfa_active = TRUE. Should we add a warn scenario for the when virtual mfa device serial_number *is not* null *and* mfa_active = TRUE? 