### PR TITLE
fix: Use `secretsmanager` instead of `secretmanager` for check Id

### DIFF
--- a/transformations/aws/compliance-premium/README.md
+++ b/transformations/aws/compliance-premium/README.md
@@ -918,10 +918,10 @@ tables: ["aws_cloudfront_distributions",
 - ✅ `sagemaker.1`: `sagemaker_notebook_instance_direct_internet_access_disabled`
 - ✅ `sagemaker.2`: `sagemaker_notebook_instance_inside_vpc`
 - ✅ `sagemaker.3`: `sagemaker_notebook_instance_root_access_check`
-- ✅ `secretmanager.1`: `secrets_should_have_automatic_rotation_enabled`
-- ✅ `secretmanager.2`: `secrets_configured_with_automatic_rotation_should_rotate_successfully`
-- ✅ `secretmanager.3`: `remove_unused_secrets_manager_secrets`
-- ✅ `secretmanager.4`: `secrets_should_be_rotated_within_a_specified_number_of_days`
+- ✅ `secretsmanager.1`: `secrets_should_have_automatic_rotation_enabled`
+- ✅ `secretsmanager.2`: `secrets_configured_with_automatic_rotation_should_rotate_successfully`
+- ✅ `secretsmanager.3`: `remove_unused_secrets_manager_secrets`
+- ✅ `secretsmanager.4`: `secrets_should_be_rotated_within_a_specified_number_of_days`
 - ✅ `sns.1`: `sns_topics_should_be_encrypted_at_rest_using_aws_kms`
 - ✅ `sns.2`: `sns_topics_should_have_message_delivery_notification_enabled`
 - ✅ `sqs.1`: `sqs_queues_should_be_encrypted_at_rest`

--- a/transformations/aws/compliance-premium/models/aws_compliance__foundational_security.sql
+++ b/transformations/aws/compliance-premium/models/aws_compliance__foundational_security.sql
@@ -342,7 +342,7 @@ with
     {{ union() }}
     ({{ redshift_default_db_name_check('foundational_security','redshift.9') }})
     {{ union() }}
-    ({{ remove_unused_secrets_manager_secrets('foundational_security','secretmanager.3') }})
+    ({{ remove_unused_secrets_manager_secrets('foundational_security','secretsmanager.3') }})
     {{ union() }}
     ({{ replication_not_public('foundational_security','dms.1') }})
     {{ union() }}
@@ -376,11 +376,11 @@ with
     {{ union() }}
     ({{ sagemaker_notebook_instance_root_access_check('foundational_security','sagemaker.3') }})
     {{ union() }}
-    ({{ secrets_configured_with_automatic_rotation_should_rotate_successfully('foundational_security','secretmanager.2') }})
+    ({{ secrets_configured_with_automatic_rotation_should_rotate_successfully('foundational_security','secretsmanager.2') }})
     {{ union() }}
-    ({{ secrets_should_be_rotated_within_a_specified_number_of_days('foundational_security','secretmanager.4') }})
+    ({{ secrets_should_be_rotated_within_a_specified_number_of_days('foundational_security','secretsmanager.4') }})
     {{ union() }}
-    ({{ secrets_should_have_automatic_rotation_enabled('foundational_security','secretmanager.1') }})
+    ({{ secrets_should_have_automatic_rotation_enabled('foundational_security','secretsmanager.1') }})
     {{ union() }}
     ({{ secrets_should_not_be_in_environment_variables('foundational_security','ecs.8') }})
     {{ union() }}


### PR DESCRIPTION
Fixes https://github.com/cloudquery/cloudquery-issues/issues/2637

We also have `secretmanager.` in the compliance policy, not sure if that should be singular or plural

https://github.com/cloudquery/policies/blob/260955f6360fde588b7037a3b41b395b3d6c2d9b/transformations/aws/compliance-premium/models/aws_compliance__pci_dss_v3_2_1.sql#L85

Also the issue mentions `secretmanager.5` which I didn't find in our code