### PR TITLE
chore: Revert "chore(main): Release transformation-aws-compliance-premium v1.14.3"

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,7 +3,7 @@
   "transformations/aws/data-resilience+FILLER": "0.0.0",
   "transformations/aws/compliance-free": "1.4.0",
   "transformations/aws/compliance-free+FILLER": "0.0.0",
-  "transformations/aws/compliance-premium": "1.14.3",
+  "transformations/aws/compliance-premium": "1.14.2",
   "transformations/aws/compliance-premium+FILLER": "0.0.0",
   "transformations/azure/compliance-free": "1.6.2",
   "transformations/azure/compliance-free+FILLER": "0.0.0",

--- a/transformations/aws/compliance-premium/CHANGELOG.md
+++ b/transformations/aws/compliance-premium/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [1.14.3](https://github.com/cloudquery/policies/compare/transformation-aws-compliance-premium-v1.14.2...transformation-aws-compliance-premium-v1.14.3) (2024-10-24)
-
-
-### Bug Fixes
-
-* Use `secretsmanager` instead of `secretmanager` for check Id ([#1114](https://github.com/cloudquery/policies/issues/1114)) ([81c3d89](https://github.com/cloudquery/policies/commit/81c3d89b2226714a88e2ddec90a90a32e959a808))
-
 ## [1.14.2](https://github.com/cloudquery/policies/compare/transformation-aws-compliance-premium-v1.14.1...transformation-aws-compliance-premium-v1.14.2) (2024-10-14)
 
 

--- a/transformations/aws/compliance-premium/dbt_project.yml
+++ b/transformations/aws/compliance-premium/dbt_project.yml
@@ -1,5 +1,5 @@
 name: aws_compliance
-version: 1.14.3
+version: 1.14.2
 config-version: 2
 profile: aws_compliance
 model-paths:


### PR DESCRIPTION
Reverts cloudquery/policies#1115

The release [failed](https://github.com/cloudquery/policies/actions/runs/11500659415/job/32011426868) so reverting and we'll do this again