### PR TITLE
fix: Update title for `ec2.19` foundational security check

### DIFF
--- a/transformations/aws/macros/ec2/security_groups_with_open_critical_ports.sql
+++ b/transformations/aws/macros/ec2/security_groups_with_open_critical_ports.sql
@@ -86,7 +86,7 @@ WITH IndividualRuleStatus AS (
 SELECT
 	'{{framework}}' as framework,
 	'{{check_id}}' as check_id,
-	'Aggregates rules of security groups with ports and IPs including ipv6' as title,	
+	'Security groups should not allow unrestricted access to ports with high risk' as title,
     account_id,
     resource_id,
     CASE


### PR DESCRIPTION
Reported by Perforce here https://cloudqueryio.slack.com/archives/C06S4CZ8K4M/p1732534709757289.

Looking at other macros in this file this should be the correct title, open to feedback