### PR TITLE
fix: Incorporate Perforce feedback

### DIFF
--- a/transformations/aws/macros/ec2/ebs_snapshot_permissions_check.sql
+++ b/transformations/aws/macros/ec2/ebs_snapshot_permissions_check.sql
@@ -19,9 +19,6 @@ SELECT DISTINCT
   snapshot_id as resource_id,
   case when
     "group" = 'all'
-    -- this is under question because
-    -- trusted accounts(user_id) do not violate this control
-        OR user_id IS DISTINCT FROM ''
     then 'fail'
     else 'pass'
   end as status
@@ -45,9 +42,6 @@ SELECT DISTINCT
   snapshot_id as resource_id,
   case when
     "group" = 'all'
-    -- this is under question because
-    -- trusted accounts(user_id) do not violate this control
-        OR user_id IS DISTINCT FROM ''
     then 'fail'
     else 'pass'
   end as status
@@ -74,9 +68,6 @@ SELECT DISTINCT
   snapshot_id as resource_id,
   case when
     JSON_VALUE(groupa) = 'all'
-    -- this is under question because
-    -- trusted accounts(user_id) do not violate this control
-        OR JSON_VALUE(user_id) IS DISTINCT FROM ''
     then 'fail'
     else 'pass'
   end as status
@@ -102,9 +93,6 @@ SELECT DISTINCT
     snapshot_id AS resource_id,
     CASE WHEN
         "group" = 'all'
-        -- this is under question because
-        -- trusted accounts(user_id) do not violate this control
-        OR user_id IS NOT NULL AND user_id <> ''
     THEN 'fail'
     ELSE 'pass'
     END AS status

--- a/transformations/aws/macros/ecs/containers_limited_read_only_root_filesystems.sql
+++ b/transformations/aws/macros/ecs/containers_limited_read_only_root_filesystems.sql
@@ -5,27 +5,45 @@
 {% macro default__containers_limited_read_only_root_filesystems(framework, check_id) %}{% endmacro %}
 
 {% macro postgres__containers_limited_read_only_root_filesystems(framework, check_id) %}
-with flat_containers as (
-        SELECT
-            arn,
-            account_id,
-            CASE
-                WHEN (container_definition ->> 'readonlyRootFilesystem')::BOOLEAN = FALSE
-                OR container_definition ->> 'readonlyRootFilesystem' IS NULL THEN 1
-                ELSE 0
-            END AS status,
-            task_role_arn,
-            max(revision) AS latest_revision
-        FROM
-            aws_ecs_task_definitions,
-			JSONB_ARRAY_ELEMENTS(container_definitions) as container_definition
-        WHERE
-            status = 'ACTIVE'
-        GROUP BY
-            arn,
-            account_id,
-            task_role_arn
-    )
+with latest_revisions as (
+    SELECT
+        arn,
+        account_id,
+        task_role_arn,
+        max(revision) AS latest_revision
+    FROM
+        aws_ecs_task_definitions
+    WHERE
+        status = 'ACTIVE'
+    GROUP BY
+        arn,
+        account_id,
+        task_role_arn
+),
+flat_containers as (
+    SELECT
+        t.arn,
+        t.account_id,
+        CASE
+            WHEN (container_definition ->> 'readonlyRootFilesystem')::BOOLEAN = FALSE
+            OR container_definition ->> 'readonlyRootFilesystem' IS NULL THEN 1
+            ELSE 0
+        END AS status,
+        t.task_role_arn,
+        lr.latest_revision
+    FROM
+        latest_revisions lr
+    JOIN
+        aws_ecs_task_definitions t
+    ON
+        lr.arn = t.arn
+        AND lr.account_id = t.account_id
+        AND lr.task_role_arn = t.task_role_arn
+        AND lr.latest_revision = t.revision,
+        JSONB_ARRAY_ELEMENTS(t.container_definitions) as container_definition
+    WHERE
+        t.status = 'ACTIVE'
+)
 select
     '{{framework}}' As framework,
     '{{check_id}}' As check_id,
@@ -41,27 +59,44 @@ from
 {% endmacro %}
 
 {% macro snowflake__containers_limited_read_only_root_filesystems(framework, check_id) %}
-with flat_containers as (
+with latest_revisions as (
         SELECT
             arn,
             account_id,
-            CASE
-                WHEN container_definition.value:readonlyRootFilesystem::BOOLEAN = FALSE
-                OR container_definition.value:readonlyRootFilesystem IS NULL THEN 1
-                ELSE 0
-            END AS status,
             task_role_arn,
-            max(revision) AS latest_revision
+            max (revision) AS latest_revision
         FROM
-            aws_ecs_task_definitions,
-            LATERAL FLATTEN(input => container_definitions) AS container_definition
+            aws_ecs_task_definitions
         WHERE
             status = 'ACTIVE'
         GROUP BY
             arn,
             account_id,
             task_role_arn
-    )
+), flat_containers as (
+        SELECT
+             t.arn,
+             t.account_id,
+             CASE
+                 WHEN container_definition.value:readonlyRootFilesystem::BOOLEAN = FALSE
+                 OR container_definition.value:readonlyRootFilesystem IS NULL THEN 1
+                 ELSE 0
+             END AS status,
+             t.task_role_arn,
+             lr.latest_revision
+        FROM
+             latest_revisions lr
+        JOIN
+             aws_ecs_task_definitions t
+        ON
+             lr.arn = t.arn
+             AND lr.account_id = t.account_id
+             AND lr.task_role_arn = t.task_role_arn
+             AND lr.latest_revision = t.revision,
+             LATERAL FLATTEN(input => t.container_definitions) AS container_definition
+        WHERE
+            t.status = 'ACTIVE'
+)
 select
     '{{framework}}' As framework,
     '{{check_id}}' As check_id,
@@ -77,27 +112,45 @@ from
 {% endmacro %}
 
 {% macro bigquery__containers_limited_read_only_root_filesystems(framework, check_id) %}
-with flat_containers as (
-        SELECT
-            arn,
-            account_id,
-            CASE
-                WHEN CAST( JSON_VALUE(container_definition.readonlyRootFilesystem) AS BOOL) = FALSE
-                OR JSON_VALUE(container_definition.readonlyRootFilesystem) IS NULL THEN 1
-                ELSE 0
-            END AS status,
-            task_role_arn,
-            max(revision) AS latest_revision
-        FROM
-            {{ full_table_name("aws_ecs_task_definitions") }},
-            UNNEST(JSON_QUERY_ARRAY(container_definitions)) AS container_definition
-        WHERE
-            status = 'ACTIVE'
-        GROUP BY
-            arn,
-            account_id,
-            task_role_arn
-    )
+with latest_revisions as (
+    SELECT
+        arn,
+        account_id,
+        task_role_arn,
+        max(revision) AS latest_revision
+    FROM
+        {{ full_table_name("aws_ecs_task_definitions") }}
+    WHERE
+        status = 'ACTIVE'
+    GROUP BY
+        arn,
+        account_id,
+        task_role_arn
+),
+flat_containers as (
+    SELECT
+        t.arn,
+        t.account_id,
+        CASE
+            WHEN CAST(JSON_VALUE(container_definition.readonlyRootFilesystem) AS BOOL) = FALSE
+            OR JSON_VALUE(container_definition.readonlyRootFilesystem) IS NULL THEN 1
+            ELSE 0
+        END AS status,
+        t.task_role_arn,
+        lr.latest_revision
+    FROM
+        latest_revisions lr
+    JOIN
+        {{ full_table_name("aws_ecs_task_definitions") }} t
+    ON
+        lr.arn = t.arn
+        AND lr.account_id = t.account_id
+        AND lr.task_role_arn = t.task_role_arn
+        AND lr.latest_revision = t.revision,
+        UNNEST(JSON_QUERY_ARRAY(t.container_definitions)) AS container_definition
+    WHERE
+    t.status = 'ACTIVE'
+)
 select
     '{{framework}}' As framework,
     '{{check_id}}' As check_id,
@@ -107,34 +160,52 @@ select
     CASE
         WHEN max(status) OVER (PARTITION BY arn) = 1 THEN 'fail'
         ELSE 'pass'
-    END as status
+        END as status
 from
     flat_containers
 {% endmacro %}
 
 {% macro athena__containers_limited_read_only_root_filesystems(framework, check_id) %}
 select * from (
-with flat_containers as (
-        SELECT
-            arn,
-            account_id,
-            CASE
-                WHEN cast(json_extract_scalar(container_definition, '$.readonlyRootFilesystem') as BOOLEAN) = FALSE
+with latest_revisions as (
+    SELECT
+        arn,
+        account_id,
+        task_role_arn,
+        max(revision) AS latest_revision
+    FROM
+        aws_ecs_task_definitions
+    WHERE
+        status = 'ACTIVE'
+    GROUP BY
+        arn,
+        account_id,
+        task_role_arn
+),
+flat_containers as (
+    SELECT
+        t.arn,
+        t.account_id,
+        CASE
+            WHEN cast(json_extract_scalar(container_definition, '$.readonlyRootFilesystem') as BOOLEAN) = FALSE
                 OR json_extract_scalar(container_definition, '$.readonlyRootFilesystem') IS NULL THEN 1
-                ELSE 0
+            ELSE 0
             END AS status,
-            task_role_arn,
-            max(revision) AS latest_revision
-        FROM
-            aws_ecs_task_definitions,
-            unnest(cast(json_parse(container_definitions) as array(json))) as t(container_definition)
-        WHERE
-            status = 'ACTIVE'
-        GROUP BY
-            arn,
-            account_id,
-            task_role_arn
-    )
+        t.task_role_arn,
+        lr.latest_revision
+    FROM
+        latest_revisions lr
+            JOIN
+        aws_ecs_task_definitions t
+        ON
+            lr.arn = t.arn
+                AND lr.account_id = t.account_id
+                AND lr.task_role_arn = t.task_role_arn
+                AND lr.latest_revision = t.revision,
+        unnest(cast(json_parse(t.container_definitions) as array(json))) as t(container_definition)
+    WHERE
+        t.status = 'ACTIVE'
+)
 select
     '{{framework}}' As framework,
     '{{check_id}}' As check_id,


### PR DESCRIPTION
[Context](https://cloudqueryio.slack.com/archives/C0774DTKDJT/p1742549144843849)

fix: ECS.5 should only show most-recent version for a task definition
fix: EC2.1 EBS snapshots should have stricter group check; customer was reporting that the check was failing when it should not.

BEGIN_COMMIT_OVERRIDE
fix: EC2.1 EBS. Make snapshots group check stricter

fix: ECS.5. Only check latest active versions of ECS task definitions

END_COMMIT_OVERRIDE