### PR TITLE
chore: Trigger release

### DIFF
--- a/transformations/aws/compliance-premium/README.md
+++ b/transformations/aws/compliance-premium/README.md
@@ -1013,3 +1013,4 @@ tables: ["aws_cloudfront_distributions",
 - ✅ `Redshift`: `cluster_publicly_accessible`
 <!-- AUTO-GENERATED-INCLUDED-CHECKS-END -->
 
+


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: EC2.1 EBS. Make snapshots group check stricter

fix: ECS.5. Only check latest active versions of ECS task definitions
END_COMMIT_OVERRIDE

Trigger a release for https://github.com/cloudquery/policies/pull/1259