### PR TITLE
fix: Remove deprecated `cloudfront.2` check

### DIFF
--- a/transformations/aws/compliance-premium/README.md
+++ b/transformations/aws/compliance-premium/README.md
@@ -742,7 +742,6 @@ tables: ["aws_cloudfront_distributions",
 - ✅ `awsconfig.1`: `config_enabled_all_regions`
 - ✅ `cloudformation.1`: `cloudformation_stack_notification_check`
 - ✅ `cloudfront.1`: `default_root_object_configured`
-- ✅ `cloudfront.2`: `origin_access_identity_enabled`
 - ✅ `cloudfront.3`: `viewer_policy_https`
 - ✅ `cloudfront.4`: `origin_failover_enabled`
 - ✅ `cloudfront.5`: `access_logs_enabled`

--- a/transformations/aws/compliance-premium/models/aws_compliance__foundational_security.sql
+++ b/transformations/aws/compliance-premium/models/aws_compliance__foundational_security.sql
@@ -278,8 +278,6 @@ with
     {{ union() }}
     ({{ not_imdsv2_instances('foundational_security','ec2.8') }})
     {{ union() }}
-    ({{ origin_access_identity_enabled('foundational_security','cloudfront.2') }})
-    {{ union() }}
     ({{ origin_failover_enabled('foundational_security','cloudfront.4') }})
     {{ union() }}
     ({{ paravirtual_instances_should_not_be_used('foundational_security','ec2.24') }})


### PR DESCRIPTION
This check was deprecated see https://docs.aws.amazon.com/securityhub/latest/userguide/controls-change-log.html

I kept the macro with the query for past reference