### PR TITLE
fix: Don't include null resources in EC2.2 check

### DIFF
--- a/transformations/aws/macros/ec2/default_sg_no_access.sql
+++ b/transformations/aws/macros/ec2/default_sg_no_access.sql
@@ -13,9 +13,36 @@ select
   arn,
   case when
       group_name='default'
-      and (array_size(parse_json(ip_permissions)) > 0 or array_size(parse_json(ip_permissions_egress)) > 0)
-      then 'fail'
-      else 'pass'
+          AND (
+          array_size(parse_json(ip_permissions)) = 0
+              OR (
+              array_size(parse_json(ip_permissions)) = 1
+                  AND parse_json(ip_permissions[0]):FromPort IS NULL
+                  AND parse_json(ip_permissions[0]):ToPort IS NULL
+                  AND parse_json(ip_permissions[0]):IpProtocol = '-1'
+                  AND array_size(parse_json(ip_permissions[0]):IpRanges) = 0
+                  AND array_size(parse_json(ip_permissions[0]):Ipv6Ranges) = 0
+                  AND array_size(parse_json(ip_permissions[0]):PrefixListIds) = 0
+                  AND array_size(parse_json(ip_permissions[0]):UserIdGroupPairs) = 1
+                  AND parse_json(ip_permissions[0]):UserIdGroupPairs[0]:GroupName IS NULL
+              )
+          )
+          AND (
+          array_size(parse_json(ip_permissions_egress)) = 0
+              OR (
+              array_size(parse_json(ip_permissions_egress)) = 1
+                  AND parse_json(ip_permissions_egress[0]):FromPort IS NULL
+                  AND parse_json(ip_permissions_egress[0]):ToPort IS NULL
+                  AND array_size(parse_json(ip_permissions_egress[0]):IpRanges) = 1
+                  AND parse_json(ip_permissions_egress[0]):IpRanges[0]:CidrIp = '0.0.0.0/0'
+                  AND parse_json(ip_permissions_egress[0]):IpRanges[0]:Description IS NULL
+                  AND array_size(parse_json(ip_permissions_egress[0]):Ipv6Ranges) = 0
+                  AND array_size(parse_json(ip_permissions_egress[0]):PrefixListIds) = 0
+                  AND array_size(parse_json(ip_permissions_egress[0]):UserIdGroupPairs) = 0
+              )
+          )
+      then 'pass'
+      else 'fail'
   end
 FROM
     aws_ec2_security_groups
@@ -29,11 +56,38 @@ select
   account_id,
   arn,
   case when
-      group_name='default' 
-      AND (jsonb_array_length(ip_permissions) > 0
-      OR jsonb_array_length(ip_permissions_egress) > 0)
-      then 'fail'
-      else 'pass'
+    group_name='default'
+    AND (
+    jsonb_array_length(ip_permissions) = 0
+        OR (
+        jsonb_array_length(ip_permissions) = 1
+            AND (ip_permissions->0->>'FromPort')::int IS NULL
+            AND (ip_permissions->0->>'ToPort')::int IS NULL
+            AND (ip_permissions->0->>'IpProtocol') = '-1'
+            AND jsonb_array_length(ip_permissions->0->'IpRanges') = 0
+            AND jsonb_array_length(ip_permissions->0->'Ipv6Ranges') = 0
+            AND jsonb_array_length(ip_permissions->0->'PrefixListIds') = 0
+            AND jsonb_array_length(ip_permissions->0->'UserIdGroupPairs') = 1
+            AND (ip_permissions->0->'UserIdGroupPairs'->0->>'GroupName') IS NULL
+        )
+    )
+    AND (
+    jsonb_array_length(ip_permissions_egress) = 0
+        OR (
+        jsonb_array_length(ip_permissions_egress) = 1
+            AND (ip_permissions_egress->0->>'FromPort')::int IS NULL
+            AND (ip_permissions_egress->0->>'ToPort')::int IS NULL
+            AND (ip_permissions_egress->0->>'IpProtocol') = '-1'
+            AND jsonb_array_length(ip_permissions_egress->0->'IpRanges') = 1
+            AND (ip_permissions_egress->0->'IpRanges'->0->>'CidrIp') = '0.0.0.0/0'
+            AND (ip_permissions_egress->0->'IpRanges'->0->>'Description') IS NULL
+            AND jsonb_array_length(ip_permissions_egress->0->'Ipv6Ranges') = 0
+            AND jsonb_array_length(ip_permissions_egress->0->'PrefixListIds') = 0
+            AND jsonb_array_length(ip_permissions_egress->0->'UserIdGroupPairs') = 0
+        )
+    )
+    then 'pass'
+   else 'fail'
   end as status
 from
     aws_ec2_security_groups
@@ -48,10 +102,37 @@ select
   arn,
   CASE
     WHEN group_name = 'default'
-         AND ARRAY_LENGTH(JSON_EXTRACT_ARRAY(ip_permissions)) > 0
-         OR ARRAY_LENGTH(JSON_EXTRACT_ARRAY(ip_permissions_egress)) > 0
-    THEN 'fail'
-    ELSE 'pass'
+      AND (
+        ARRAY_LENGTH(JSON_EXTRACT_ARRAY(ip_permissions)) = 0
+          OR (
+          ARRAY_LENGTH(JSON_EXTRACT_ARRAY(ip_permissions)) = 1
+            AND JSON_EXTRACT_SCALAR(JSON_EXTRACT_ARRAY(ip_permissions)[OFFSET(0)], '$.FromPort') IS NULL
+            AND JSON_EXTRACT_SCALAR(JSON_EXTRACT_ARRAY(ip_permissions)[OFFSET(0)], '$.ToPort') IS NULL
+            AND JSON_EXTRACT_SCALAR(JSON_EXTRACT_ARRAY(ip_permissions)[OFFSET(0)], '$.IpProtocol') = '-1'
+            AND ARRAY_LENGTH(JSON_EXTRACT_ARRAY(JSON_EXTRACT_ARRAY(ip_permissions)[OFFSET(0)], '$.IpRanges')) = 0
+            AND ARRAY_LENGTH(JSON_EXTRACT_ARRAY(JSON_EXTRACT_ARRAY(ip_permissions)[OFFSET(0)], '$.Ipv6Ranges')) = 0
+            AND ARRAY_LENGTH(JSON_EXTRACT_ARRAY(JSON_EXTRACT_ARRAY(ip_permissions)[OFFSET(0)], '$.PrefixListIds')) = 0
+            AND ARRAY_LENGTH(JSON_EXTRACT_ARRAY(JSON_EXTRACT_ARRAY(ip_permissions)[OFFSET(0)], '$.UserIdGroupPairs')) = 1
+            AND JSON_EXTRACT_SCALAR(JSON_EXTRACT_ARRAY(JSON_EXTRACT_ARRAY(ip_permissions)[OFFSET(0)], '$.UserIdGroupPairs')[OFFSET(0)], '$.GroupName') IS NULL
+          )
+        )
+      AND (
+        ARRAY_LENGTH(JSON_EXTRACT_ARRAY(ip_permissions_egress)) = 0
+          OR (
+          ARRAY_LENGTH(JSON_EXTRACT_ARRAY(ip_permissions_egress)) = 1
+            AND JSON_EXTRACT_SCALAR(JSON_EXTRACT_ARRAY(ip_permissions_egress)[OFFSET(0)], '$.FromPort') IS NULL
+            AND JSON_EXTRACT_SCALAR(JSON_EXTRACT_ARRAY(ip_permissions_egress)[OFFSET(0)], '$.ToPort') IS NULL
+            AND JSON_EXTRACT_SCALAR(JSON_EXTRACT_ARRAY(ip_permissions_egress)[OFFSET(0)], '$.IpProtocol') = '-1'
+            AND ARRAY_LENGTH(JSON_EXTRACT_ARRAY(JSON_EXTRACT_ARRAY(ip_permissions_egress)[OFFSET(0)], '$.IpRanges')) = 1
+            AND JSON_EXTRACT_SCALAR(JSON_EXTRACT_ARRAY(JSON_EXTRACT_ARRAY(ip_permissions_egress)[OFFSET(0)], '$.IpRanges')[OFFSET(0)], '$.CidrIp') = '0.0.0.0/0'
+            AND JSON_EXTRACT_SCALAR(JSON_EXTRACT_ARRAY(JSON_EXTRACT_ARRAY(ip_permissions_egress)[OFFSET(0)], '$.IpRanges')[OFFSET(0)], '$.Description') IS NULL
+            AND ARRAY_LENGTH(JSON_EXTRACT_ARRAY(JSON_EXTRACT_ARRAY(ip_permissions_egress)[OFFSET(0)], '$.Ipv6Ranges')) = 0
+            AND ARRAY_LENGTH(JSON_EXTRACT_ARRAY(JSON_EXTRACT_ARRAY(ip_permissions_egress)[OFFSET(0)], '$.PrefixListIds')) = 0
+            AND ARRAY_LENGTH(JSON_EXTRACT_ARRAY(JSON_EXTRACT_ARRAY(ip_permissions_egress)[OFFSET(0)], '$.UserIdGroupPairs')) = 0
+          )
+        )
+      THEN 'pass'
+    ELSE 'fail'
   END AS status
 from
     {{ full_table_name("aws_ec2_security_groups") }}
@@ -66,7 +147,7 @@ select
   arn,
   case when
       group_name='default'
-      and 
+      and
       json_array_length(json_parse(ip_permissions)) > 0
       or
       json_array_length(json_parse(ip_permissions_egress)) > 0


### PR DESCRIPTION
AWS includes "sensible default" (null) resources so the previous query was marking EC2.2 as `fail` because these were present.

The enhanced logic detects and ignores these default resources.