### PR TITLE
feat: Do not show non-default SGs

### DIFF
--- a/transformations/aws/macros/ec2/default_sg_no_access.sql
+++ b/transformations/aws/macros/ec2/default_sg_no_access.sql
@@ -46,6 +46,8 @@ select
   end
 FROM
     aws_ec2_security_groups
+WHERE
+    group_name = 'default'
 {% endmacro %}
 
 {% macro postgres__default_sg_no_access(framework, check_id) %}
@@ -91,6 +93,8 @@ select
   end as status
 from
     aws_ec2_security_groups
+WHERE
+    group_name = 'default'
 {% endmacro %}
 
 {% macro bigquery__default_sg_no_access(framework, check_id) %}
@@ -136,6 +140,8 @@ select
   END AS status
 from
     {{ full_table_name("aws_ec2_security_groups") }}
+WHERE
+    group_name = 'default'
 {% endmacro %}
 
 {% macro athena__default_sg_no_access(framework, check_id) %}
@@ -156,4 +162,6 @@ select
   end
 FROM
     aws_ec2_security_groups
+WHERE
+    group_name = 'default'
 {% endmacro %}

--- a/transformations/aws/macros/ec2/default_sg_no_access.sql
+++ b/transformations/aws/macros/ec2/default_sg_no_access.sql
@@ -12,8 +12,7 @@ select
   account_id,
   arn AS resource_id,
   case when
-      group_name='default'
-          AND (
+          (
           array_size(parse_json(ip_permissions)) = 0
               OR (
               array_size(parse_json(ip_permissions)) = 1
@@ -26,8 +25,7 @@ select
                   AND array_size(parse_json(ip_permissions[0]):UserIdGroupPairs) = 1
                   AND parse_json(ip_permissions[0]):UserIdGroupPairs[0]:GroupName IS NULL
               )
-          )
-          AND (
+          ) AND (
           array_size(parse_json(ip_permissions_egress)) = 0
               OR (
               array_size(parse_json(ip_permissions_egress)) = 1
@@ -58,8 +56,7 @@ select
   account_id,
   arn as resource_id,
   case when
-    group_name='default'
-    AND (
+    (
     jsonb_array_length(ip_permissions) = 0
         OR (
         jsonb_array_length(ip_permissions) = 1
@@ -72,8 +69,7 @@ select
             AND jsonb_array_length(ip_permissions->0->'UserIdGroupPairs') = 1
             AND (ip_permissions->0->'UserIdGroupPairs'->0->>'GroupName') IS NULL
         )
-    )
-    AND (
+    ) AND (
     jsonb_array_length(ip_permissions_egress) = 0
         OR (
         jsonb_array_length(ip_permissions_egress) = 1
@@ -105,8 +101,7 @@ select
   account_id,
   arn as resource_id,
   CASE
-    WHEN group_name = 'default'
-      AND (
+      WHEN (
         ARRAY_LENGTH(JSON_EXTRACT_ARRAY(ip_permissions)) = 0
           OR (
           ARRAY_LENGTH(JSON_EXTRACT_ARRAY(ip_permissions)) = 1
@@ -119,8 +114,7 @@ select
             AND ARRAY_LENGTH(JSON_EXTRACT_ARRAY(JSON_EXTRACT_ARRAY(ip_permissions)[OFFSET(0)], '$.UserIdGroupPairs')) = 1
             AND JSON_EXTRACT_SCALAR(JSON_EXTRACT_ARRAY(JSON_EXTRACT_ARRAY(ip_permissions)[OFFSET(0)], '$.UserIdGroupPairs')[OFFSET(0)], '$.GroupName') IS NULL
           )
-        )
-      AND (
+      ) AND (
         ARRAY_LENGTH(JSON_EXTRACT_ARRAY(ip_permissions_egress)) = 0
           OR (
           ARRAY_LENGTH(JSON_EXTRACT_ARRAY(ip_permissions_egress)) = 1
@@ -152,8 +146,6 @@ select
   account_id,
   arn as resource_id,
   case when
-      group_name='default'
-      and
       json_array_length(json_parse(ip_permissions)) > 0
       or
       json_array_length(json_parse(ip_permissions_egress)) > 0


### PR DESCRIPTION
At present we have a number of conditions within rule ec2.2 which are predicated on:

```
default group name + no ingress rules, no egress rules = pass 
default group name + expressly deny ingress, expressly deny egress = pass 
default group name + no ingress rules, expressly deny egress  = pass 
default group name + expreslly deny ingress, no egress rules = pass 
default group name + any other combination = fail
```

However, the check currently also shows FAIL for `any other group name + any combination`.

We should hide non-default group names by filtering for the `default` group name before evaluating the rest of ec2.2.