### PR TITLE
fix: Only pick latest revision

### DIFF
--- a/transformations/aws/compliance-premium/README.md
+++ b/transformations/aws/compliance-premium/README.md
@@ -1011,3 +1011,4 @@ tables: ["aws_cloudfront_distributions",
 - ✅ `RDS`: `rds_db_instances_should_prohibit_public_access`
 - ✅ `Redshift`: `cluster_publicly_accessible`
 <!-- AUTO-GENERATED-INCLUDED-CHECKS-END -->
+

--- a/transformations/aws/macros/ecs/containers_limited_read_only_root_filesystems.sql
+++ b/transformations/aws/macros/ecs/containers_limited_read_only_root_filesystems.sql
@@ -6,7 +6,7 @@
 
 {% macro postgres__containers_limited_read_only_root_filesystems(framework, check_id) %}
 with latest_revisions as (
-    SELECT
+    SELECT distinct on (account_id, task_role_arn)
         arn,
         account_id,
         task_role_arn,
@@ -19,6 +19,7 @@ with latest_revisions as (
         arn,
         account_id,
         task_role_arn
+	ORDER BY account_id, task_role_arn, latest_revision DESC
 ),
 flat_containers as (
     SELECT


### PR DESCRIPTION
The revision is part of the ARN so if we want to take only the latest one we need to de-dup the results.

This PR fixes the issue only for Postgres