### PR TITLE
fix: Modify ec2.18 SQL to match AWS rule

### DIFF
--- a/transformations/aws/macros/ec2/security_groups_with_access_to_unauthorized_ports.sql
+++ b/transformations/aws/macros/ec2/security_groups_with_access_to_unauthorized_ports.sql
@@ -12,15 +12,15 @@ SELECT
   account_id,
   arn as resource_id,
   CASE
-    WHEN ip_protocol != 'tcp' THEN 'fail'
+    WHEN ip_protocol != 'tcp' THEN 'fail' -- No parameterised allowlist in place at the moment.
     WHEN ip IN ('0.0.0.0/0') OR ip6 IN ('::/0') THEN
       CASE
-        WHEN from_port IS NULL THEN 'fail' -- Unrestricted traffic
-        WHEN to_port IS NULL THEN 'fail' -- Unrestricted traffic
-        WHEN from_port IN (80, 443) AND to_port IN (80, 443) THEN 'pass' -- Authorized ports
-        ELSE 'fail' -- Any other port
+        WHEN from_port::TEXT IS NULL THEN 'fail' -- Unrestricted traffic
+        WHEN to_port::TEXT IS NULL THEN 'fail' -- Unrestricted traffic
+        WHEN TRIM(from_port::TEXT) IN ('80', '80,443', '443,80', '443') AND TRIM(to_port::TEXT) IN ('80', '80,443', '443,80', '443') THEN 'pass' -- Authorized ports
+        ELSE 'fail' -- Any other port; no parameterised allowlist in place at the moment.
       END
-    ELSE 'pass' -- Restricted IPs
+    ELSE 'pass' -- "NOT_APPLICABLE" per https://docs.aws.amazon.com/config/latest/developerguide/vpc-sg-open-only-to-authorized-ports.html
   END AS status
 FROM {{ref('aws_compliance__security_group_ingress_rules')}}
 {% endmacro %}
@@ -32,15 +32,15 @@ WITH IndividualRuleStatus AS (
     account_id,
     arn as resource_id,
     CASE
-      WHEN ip_protocol != 'tcp' THEN 'fail'
+      WHEN ip_protocol != 'tcp' THEN 'fail' -- No parameterised allowlist in place at the moment.
       WHEN ip IN ('0.0.0.0/0') OR ip6 IN ('::/0') THEN
       CASE
-        WHEN from_port IS NULL THEN 'fail' -- Unrestricted traffic
-        WHEN to_port IS NULL THEN 'fail' -- Unrestricted traffic
-        WHEN from_port IN (80, 443) AND to_port IN (80, 443) THEN 'pass' -- Authorized ports
-        ELSE 'fail' -- Any other port
+        WHEN from_port::TEXT IS NULL THEN 'fail' -- Unrestricted traffic
+        WHEN to_port::TEXT IS NULL THEN 'fail' -- Unrestricted traffic
+        WHEN TRIM(from_port::TEXT) IN ('80', '80,443', '443,80', '443') AND TRIM(to_port::TEXT) IN ('80', '80,443', '443,80', '443') THEN 'pass' -- Authorized ports
+        ELSE 'fail' -- Any other port; no parameterised allowlist in place at the moment.
       END
-      ELSE 'pass' -- Restricted IPs
+      ELSE 'pass' -- "NOT_APPLICABLE" per https://docs.aws.amazon.com/config/latest/developerguide/vpc-sg-open-only-to-authorized-ports.html
     END AS status
   FROM {{ ref('aws_compliance__security_group_ingress_rules') }}
 )
@@ -72,15 +72,15 @@ SELECT
   account_id,
   arn as resource_id,
   CASE
-    WHEN ip_protocol != 'tcp' THEN 'fail'
+    WHEN ip_protocol != 'tcp' THEN 'fail' -- No parameterised allowlist in place at the moment.
     WHEN ip IN ('0.0.0.0/0') OR ip6 IN ('::/0') THEN
       CASE
-        WHEN from_port IS NULL THEN 'fail' -- Unrestricted traffic
-        WHEN to_port IS NULL THEN 'fail' -- Unrestricted traffic
-        WHEN from_port IN (80, 443) AND to_port IN (80, 443) THEN 'pass' -- Authorized ports
-        ELSE 'fail' -- Any other port
+        WHEN CAST(from_port AS STRING) IS NULL THEN 'fail' -- Unrestricted traffic
+        WHEN CAST(to_port AS STRING) IS NULL THEN 'fail' -- Unrestricted traffic
+        WHEN TRIM(CAST(from_port AS STRING)) IN ('80', '80,443', '443,80', '443') AND TRIM(CAST(to_port AS STRING)) IN ('80', '80,443', '443,80', '443') THEN 'pass' -- Authorized ports
+        ELSE 'fail' -- Any other port; no parameterised allowlist in place at the moment.
       END
-      ELSE 'pass' -- Restricted IPs
+      ELSE 'pass' -- "NOT_APPLICABLE" per https://docs.aws.amazon.com/config/latest/developerguide/vpc-sg-open-only-to-authorized-ports.html
     END AS status
 FROM {{ref('aws_compliance__security_group_ingress_rules')}}
 {% endmacro %}
@@ -93,15 +93,15 @@ WITH IndividualRuleStatus AS (
     account_id,
     arn as resource_id,
     CASE
-      WHEN ip_protocol != 'tcp' THEN 'fail'
+      WHEN ip_protocol != 'tcp' THEN 'fail' -- No parameterised allowlist in place at the moment.
       WHEN ip IN ('0.0.0.0/0') OR ip6 IN ('::/0') THEN
         CASE
-          WHEN from_port IS NULL THEN 'fail' -- Unrestricted traffic
-          WHEN to_port IS NULL THEN 'fail' -- Unrestricted traffic
-          WHEN from_port IN (80, 443) AND to_port IN (80, 443) THEN 'pass' -- Authorized ports
-          ELSE 'fail' -- Any other port
+            WHEN CAST(from_port AS VARCHAR) IS NULL THEN 'fail' -- Unrestricted traffic
+            WHEN CAST(to_port AS VARCHAR) IS NULL THEN 'fail' -- Unrestricted traffic
+            WHEN TRIM(CAST(from_port AS VARCHAR)) IN ('80', '80,443', '443,80', '443') AND TRIM(CAST(to_port AS VARCHAR)) IN ('80', '80,443', '443,80', '443') THEN 'pass' -- Authorized ports
+          ELSE 'fail' -- Any other port; no parameterised allowlist in place at the moment.
         END
-      ELSE 'pass' -- Restricted IPs
+      ELSE 'pass' -- "NOT_APPLICABLE" per https://docs.aws.amazon.com/config/latest/developerguide/vpc-sg-open-only-to-authorized-ports.html
     END AS status
   FROM {{ref('aws_compliance__security_group_ingress_rules')}}
 )

--- a/transformations/aws/macros/ec2/security_groups_with_access_to_unauthorized_ports.sql
+++ b/transformations/aws/macros/ec2/security_groups_with_access_to_unauthorized_ports.sql
@@ -11,16 +11,17 @@ SELECT
   'Aggregates rules of security groups with ports and IPs including ipv6' as title,
   account_id,
   arn as resource_id,
-  case when
-    (ip = '0.0.0.0/0' OR ip = '::/0')
-    AND (from_port IS NULL AND to_port IS NULL) -- all prots
-    OR from_port IS DISTINCT FROM 80
-    OR to_port IS DISTINCT FROM 80
-    OR from_port IS DISTINCT FROM 443
-    OR to_port IS DISTINCT FROM 443
-    then 'fail'
-    else 'pass'
-  end
+  CASE
+    WHEN ip_protocol != 'tcp' THEN 'fail'
+    WHEN ip IN ('0.0.0.0/0') OR ip6 IN ('::/0') THEN
+      CASE
+        WHEN from_port IS NULL THEN 'fail' -- Unrestricted traffic
+        WHEN to_port IS NULL THEN 'fail' -- Unrestricted traffic
+        WHEN from_port IN (80, 443) AND to_port IN (80, 443) THEN 'pass' -- Authorized ports
+        ELSE 'fail' -- Any other port
+      END
+    ELSE 'pass' -- Restricted IPs
+  END AS status
 FROM {{ref('aws_compliance__security_group_ingress_rules')}}
 {% endmacro %}
 
@@ -28,19 +29,19 @@ FROM {{ref('aws_compliance__security_group_ingress_rules')}}
 -- uses view which uses aws_security_group_ingress_rules.sql query
 WITH IndividualRuleStatus AS (
   SELECT
-      account_id,
+    account_id,
     arn as resource_id,
-    case when
-      (ip = '0.0.0.0/0' OR ip = '::/0')
-      AND ((from_port IS NULL AND to_port IS NULL) -- all prots
-      OR from_port IS DISTINCT FROM 80
-      OR to_port IS DISTINCT FROM 80
-      OR from_port IS DISTINCT FROM 443
-      OR to_port IS DISTINCT FROM 443
-      OR to_port IS DISTINCT FROM 443)
-      then 'fail'
-      else 'pass'
-    end as status
+    CASE
+      WHEN ip_protocol != 'tcp' THEN 'fail'
+      WHEN ip IN ('0.0.0.0/0') OR ip6 IN ('::/0') THEN
+      CASE
+        WHEN from_port IS NULL THEN 'fail' -- Unrestricted traffic
+        WHEN to_port IS NULL THEN 'fail' -- Unrestricted traffic
+        WHEN from_port IN (80, 443) AND to_port IN (80, 443) THEN 'pass' -- Authorized ports
+        ELSE 'fail' -- Any other port
+      END
+      ELSE 'pass' -- Restricted IPs
+    END AS status
   FROM {{ ref('aws_compliance__security_group_ingress_rules') }}
 )
 
@@ -70,16 +71,17 @@ SELECT
   'Aggregates rules of security groups with ports and IPs including ipv6' as title,
   account_id,
   arn as resource_id,
-  case when
-    (ip = '0.0.0.0/0' OR ip = '::/0')
-    AND (from_port IS NULL AND to_port IS NULL) -- all prots
-    OR from_port IS DISTINCT FROM 80
-    OR to_port IS DISTINCT FROM 80
-    OR from_port IS DISTINCT FROM 443
-    OR to_port IS DISTINCT FROM 443
-    then 'fail'
-    else 'pass'
-  end
+  CASE
+    WHEN ip_protocol != 'tcp' THEN 'fail'
+    WHEN ip IN ('0.0.0.0/0') OR ip6 IN ('::/0') THEN
+      CASE
+        WHEN from_port IS NULL THEN 'fail' -- Unrestricted traffic
+        WHEN to_port IS NULL THEN 'fail' -- Unrestricted traffic
+        WHEN from_port IN (80, 443) AND to_port IN (80, 443) THEN 'pass' -- Authorized ports
+        ELSE 'fail' -- Any other port
+      END
+      ELSE 'pass' -- Restricted IPs
+    END AS status
 FROM {{ref('aws_compliance__security_group_ingress_rules')}}
 {% endmacro %}
 
@@ -88,16 +90,19 @@ FROM {{ref('aws_compliance__security_group_ingress_rules')}}
 select * from (
 WITH IndividualRuleStatus AS (
   SELECT
-      account_id,
+    account_id,
     arn as resource_id,
-    case when
-      (ip = '0.0.0.0/0' OR ip = '::/0')
-      AND ((from_port IS NULL AND to_port IS NULL) -- all ports
-      OR (from_port <> 80 AND to_port <> 80) -- not only port 80
-      OR (from_port <> 443 AND to_port <> 443)) -- not only port 443
-      then 'fail'
-      else 'pass'
-    end as status
+    CASE
+      WHEN ip_protocol != 'tcp' THEN 'fail'
+      WHEN ip IN ('0.0.0.0/0') OR ip6 IN ('::/0') THEN
+        CASE
+          WHEN from_port IS NULL THEN 'fail' -- Unrestricted traffic
+          WHEN to_port IS NULL THEN 'fail' -- Unrestricted traffic
+          WHEN from_port IN (80, 443) AND to_port IN (80, 443) THEN 'pass' -- Authorized ports
+          ELSE 'fail' -- Any other port
+        END
+      ELSE 'pass' -- Restricted IPs
+    END AS status
   FROM {{ref('aws_compliance__security_group_ingress_rules')}}
 )
 

--- a/transformations/aws/macros/security_group_egress_rules.sql
+++ b/transformations/aws/macros/security_group_egress_rules.sql
@@ -12,8 +12,8 @@ select
     arn,
     group_id as id,
     vpc_id,
-    (i->>'FromPort')::integer AS from_port,
-        (i->>'ToPort')::integer AS to_port,
+    CAST((i->>'FromPort')::TEXT AS TEXT) AS from_port,
+        CAST((i->>'ToPort')::TEXT AS TEXT) to_port,
         i->>'IpProtocol' AS ip_protocol,
     ip_ranges->>'CidrIp' AS ip,
     ip6_ranges->>'CidrIpv6' AS ip6
@@ -30,8 +30,8 @@ select
     arn,
     group_id as id,
     vpc_id,
-    CAST(JSON_VALUE(i.FromPort) AS INT64) AS from_port,
-    CAST(JSON_VALUE(i.ToPort) AS INT64) AS to_port,
+    CAST(JSON_VALUE(i.FromPort) AS STRING) AS from_port,
+    CAST(JSON_VALUE(i.ToPort) AS STRING) AS to_port,
     JSON_VALUE(i.IpProtocol) AS ip_protocol,
     JSON_VALUE(ip_ranges.CidrIp) AS ip,
     JSON_VALUE(ip6_ranges.CidrIpv6) AS ip6
@@ -51,8 +51,8 @@ select
     arn,
     group_id as id,
     vpc_id,
-    i.value:FromPort::number AS from_port,
-    i.value:ToPort::number AS to_port,
+    CAST(i.value:FromPort::TEXT AS TEXT) AS from_port,
+    CAST(i.value:ToPort::TEXT AS TEXT) AS to_port,
     i.value:IpProtocol AS ip_protocol,
     ip_ranges.value:CidrIp AS ip,
     ip6_ranges.value:CidrIpv6 AS ip6
@@ -69,8 +69,8 @@ SELECT
     sg.arn,
     sg.group_id AS id,
     sg.vpc_id,
-    cast(json_extract(ip_permission, '$.FromPort') as int) AS from_port,
-    cast(json_extract(ip_permission, '$.ToPort') as int) AS to_port,
+    cast(json_extract_scalar(ip_permission, '$.FromPort') AS varchar) AS from_port,
+    cast(json_extract_scalar(ip_permission, '$.ToPort') AS varchar) AS to_port,
     json_extract_scalar(ip_permission, '$.IpProtocol') AS ip_protocol,
     json_extract_scalar(ip_range, '$') AS ip,
     json_extract_scalar(ip6_range, '$') AS ip6


### PR DESCRIPTION
AWS rule states:

`This control checks whether the security groups allow unrestricted incoming traffic. The control fails if ports allow unrestricted traffic on ports other than 80 and 443, which are default values for parameter authorizedTcpPorts.`

The from_ports are not relevant to this assessment. Only internet-facing IPs are relevant.