### PR TITLE
fix: Fix image paths

### DIFF
--- a/visualizations/aws/asset_inventory/README.md
+++ b/visualizations/aws/asset_inventory/README.md
@@ -27,4 +27,4 @@ This contains an AWS Asset Inventory Dashboard for Grafana on top of CloudQuery 
 
 Once you have connected Grafana to your Postgres database and have imported the dashboard template, you should see a dashboard similar to this one:
 
-![AWS Asset Inventory](/images/asset_inventory_dash.png)
+![AWS Asset Inventory](./images/asset_inventory_dash.png)

--- a/visualizations/aws/data_resilience/README.md
+++ b/visualizations/aws/data_resilience/README.md
@@ -28,4 +28,4 @@ This package contains an AWS Resilience and Backup Dashboard for Grafana on top 
 
 Once you have connected Grafana to your Postgres database and have imported the AWS Asset Inventory template, you will see a dashboard similar to this one:
 
-![AWS Data Resilience](/images/aws-resiliency-dash.png)
+![AWS Data Resilience](./images/aws-resiliency-dash.png)


### PR DESCRIPTION
The current image paths break the publishing step, e.g.

```
Error: failed to create new draft version: failed to process doc images: error processing image "/images/asset_inventory_dash.png": open /images/asset_inventory_dash.png: no such file or directory
```

Looking at other transformations, they use relative paths.