### PR TITLE
chore: Disable WIP prefix validation for PR titles

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -47,7 +47,7 @@ jobs:
           # special "[WIP]" prefix to indicate this state. This will avoid the
           # validation of the PR title and the pull request checks remain pending.
           # Note that a second check will be reported if this is enabled.
-          wip: true
+          wip: false
           # When using "Squash and merge" on a PR with only one commit, GitHub
           # will suggest using that commit message instead of the PR title for the
           # merge commit, and it's easy to commit this by mistake. Enable this option


### PR DESCRIPTION
Changed WIP option to false to disable validation for PR titles.

Otherwise we need PR write permissions