### PR TITLE
chore: Disable Renovate python-version updates in workflows

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,5 +18,10 @@
         '/^dbt-/',
       ],
     },
+    {
+      matchManagers: ['github-actions'],
+      matchDepNames: ['python'],
+      enabled: false,
+    },
   ],
 }


### PR DESCRIPTION
Disables Renovate from bumping the \`actions/setup-python\` \`python-version\` in workflows so dbt-driven transformations stay on Python 3.11 (Python 3.14 currently breaks via dbt-common -> mashumaro). See [#1625](https://github.com/cloudquery/policies/pull/1625) for the failure that motivated this.